### PR TITLE
Merge of createAnswer and editAnswer work from Anil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+quora-api/target
+quora-db/target
+quora-service/target
+*.iml
+.idea/compiler.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,11 +6,17 @@
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
+        <module name="quora-api" />
         <module name="quora-db" />
         <module name="quora-service" />
-        <module name="quora-api" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="quora" target="1.8" />
+      <module name="quora-api" target="1.8" />
+      <module name="quora-db" target="1.8" />
+      <module name="quora-service" target="1.8" />
+    </bytecodeTargetLevel>
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">

--- a/quora-api/src/main/java/com/upgrad/quora/api/controller/AnswerController.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/controller/AnswerController.java
@@ -1,0 +1,102 @@
+package com.upgrad.quora.api.controller;
+
+import com.upgrad.quora.api.model.AnswerEditRequest;
+import com.upgrad.quora.api.model.AnswerEditResponse;
+import com.upgrad.quora.api.model.AnswerRequest;
+import com.upgrad.quora.api.model.AnswerResponse;
+import com.upgrad.quora.service.business.AnswerService;
+import com.upgrad.quora.service.business.AuthenticationService;
+import com.upgrad.quora.service.business.QuestionService;
+import com.upgrad.quora.service.entity.AnswerEntity;
+import com.upgrad.quora.service.entity.QuestionEntity;
+import com.upgrad.quora.service.entity.UserAuthEntity;
+import com.upgrad.quora.service.entity.UserEntity;
+import com.upgrad.quora.service.exception.AnswerNotFoundException;
+import com.upgrad.quora.service.exception.AuthenticationFailedException;
+import com.upgrad.quora.service.exception.AuthorizationFailedException;
+import com.upgrad.quora.service.exception.InvalidQuestionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/")
+public class AnswerController {
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private AnswerService answerService;
+
+    @Autowired
+    private QuestionService questionService;
+
+    @RequestMapping(method = RequestMethod.POST,
+            path = "/question/{questionId}/answer/create",
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<AnswerResponse> postAnswer(
+            @RequestHeader("authorization") final String authorization,
+            @PathVariable("questionId") final String questionId,
+            final AnswerRequest answerRequest
+    ) throws  AuthorizationFailedException,AuthenticationFailedException,InvalidQuestionException {
+        String accessToken = authenticationService.getBearerAccessToken(authorization);
+        //Check if the bearer authentication exists
+        UserAuthEntity userAuthEntity = authenticationService.validateBearerAuthentication(accessToken, "to post a answer");
+        QuestionEntity questionEntity = questionService.getQuestionById(questionId);
+
+        UserEntity user = userAuthEntity.getUser();
+        AnswerEntity answerEntity = new AnswerEntity();
+        answerEntity.setUuid(UUID.randomUUID().toString());
+        answerEntity.setAns(answerRequest.getAnswer());
+        answerEntity.setDate(ZonedDateTime.now());
+        answerEntity.setUserEntity(user);
+        answerEntity.setQuestionEntity(questionEntity);
+
+        // create answer
+        answerService.createAnswer(answerEntity);
+        AnswerResponse answerResponse = new AnswerResponse().id(answerEntity.getUuid()).status("ANSWER CREATED");
+        return new ResponseEntity<AnswerResponse>(answerResponse,HttpStatus.OK);
+    }
+
+    //PUT Request
+    @RequestMapping(method = RequestMethod.PUT,
+            path = "/answer/edit/{answerId}",
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<AnswerEditResponse>
+    editAnswer(@RequestHeader("authorization") final String authorization,
+               @PathVariable("answerId") final String answerId,
+               final AnswerEditRequest answerEditRequest
+    ) throws AuthorizationFailedException,
+            InvalidQuestionException,
+            AuthenticationFailedException, AnswerNotFoundException {
+
+        String accessToken =
+                authenticationService.getBearerAccessToken(authorization);
+        //Check if the bearer authentication exists
+        UserAuthEntity userAuthEntity =
+                authenticationService.validateBearerAuthentication(
+                        accessToken,
+                        "to edit the answer"
+                );
+        UserEntity user = userAuthEntity.getUser();
+        // Edit question
+        AnswerEntity answerEntity =
+                answerService.editAnswer(
+                        answerEditRequest.getContent(),
+                        user,
+                        answerId
+                );
+        AnswerEditResponse answerEditResponse =
+                new AnswerEditResponse()
+                        .id(answerEntity.getUuid())
+                        .status("ANSWER EDITED");
+        return new ResponseEntity<AnswerEditResponse>(answerEditResponse,HttpStatus.OK);
+    }
+
+}
+

--- a/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
@@ -53,4 +53,11 @@ public class RestExceptionHandler {
         );
     }
 
+    @ExceptionHandler(AnswerNotFoundException.class)
+    public ResponseEntity<ErrorResponse> answerNotFoundException(AnswerNotFoundException exc, WebRequest request) {
+        return new ResponseEntity<ErrorResponse>(
+                new ErrorResponse().code(exc.getCode()).message(exc.getErrorMessage()), HttpStatus.NOT_FOUND
+        );
+    }
+
 }

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/AnswerControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/AnswerControllerTest.java
@@ -1,4 +1,4 @@
-/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 
 import org.junit.Test;
@@ -79,63 +79,62 @@ public class AnswerControllerTest {
                 .andExpect(status().isForbidden())
                 .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-003"));
     }
-
-    //This test case passes when you try to delete the answer but the JWT token entered does not exist in the database.
-    @Test
-    public void deleteAnswerWithNonExistingAccessToken() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "non_existing_access_token"))
-                .andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-001"));
-    }
-
-    //This test case passes when you try to delete the answer and the JWT token entered exists in the database but the user corresponding to that JWT token is signed out.
-    @Test
-    public void deleteAnswerWithSignedOutUser() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "database_accesstoken3"))
-                .andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-002"));
-    }
-
-    //This test case passes when you try to delete the answer which does not exist in the database.
-    @Test
-    public void deleteNonExistingAnswer() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/non_existing_answer_uuid").header("authorization", "database_accesstoken1"))
-                .andExpect(status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ANS-001"));
-    }
-
-    //This test case passes when you try to delete the answer and the JWT token entered exists in the database and the user corresponding to that JWT token is signed in but the corresponding user is not the owner of the answer or he is not the admin.
-    @Test
-    public void deleteAnswerWithoutOwnership() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "database_accesstoken2"))
-                .andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-003"));
-    }
-
-    //This test case passes when you try to get all the answers posted for a specific question but the JWT token entered does not exist in the database.
-    @Test
-    public void getAllAnswersToQuestionWithNonExistingAccessToken() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/answer/all/database_question_uuid").header("authorization", "non_existing_access_token"))
-                .andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-001"));
-    }
-
-    //This test case passes when you try to get all the answers posted for a specific question and the JWT token entered exists in the database but the user corresponding to that JWT token is signed out.
-    @Test
-    public void getAllAnswersToQuestionWithSignedOutUser() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/answer/all/database_question_uuid").header("authorization", "database_accesstoken3"))
-                .andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-002"));
-    }
-
-    //This test case passes when you try to get all the answers posted for a specific question which does not exist in the database.
-    @Test
-    public void getAllAnswersToNonExistingQuestion() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/answer/all/non_existing_question_uuid").header("authorization", "database_accesstoken"))
-                .andExpect(status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("code").value("QUES-001"));
-    }
+//
+//    //This test case passes when you try to delete the answer but the JWT token entered does not exist in the database.
+//    @Test
+//    public void deleteAnswerWithNonExistingAccessToken() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "non_existing_access_token"))
+//                .andExpect(status().isForbidden())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-001"));
+//    }
+//
+//    //This test case passes when you try to delete the answer and the JWT token entered exists in the database but the user corresponding to that JWT token is signed out.
+//    @Test
+//    public void deleteAnswerWithSignedOutUser() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "database_accesstoken3"))
+//                .andExpect(status().isForbidden())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-002"));
+//    }
+//
+//    //This test case passes when you try to delete the answer which does not exist in the database.
+//    @Test
+//    public void deleteNonExistingAnswer() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/non_existing_answer_uuid").header("authorization", "database_accesstoken1"))
+//                .andExpect(status().isNotFound())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ANS-001"));
+//    }
+//
+//    //This test case passes when you try to delete the answer and the JWT token entered exists in the database and the user corresponding to that JWT token is signed in but the corresponding user is not the owner of the answer or he is not the admin.
+//    @Test
+//    public void deleteAnswerWithoutOwnership() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.delete("/answer/delete/database_answer_uuid").header("authorization", "database_accesstoken2"))
+//                .andExpect(status().isForbidden())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-003"));
+//    }
+//
+//    //This test case passes when you try to get all the answers posted for a specific question but the JWT token entered does not exist in the database.
+//    @Test
+//    public void getAllAnswersToQuestionWithNonExistingAccessToken() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.get("/answer/all/database_question_uuid").header("authorization", "non_existing_access_token"))
+//                .andExpect(status().isForbidden())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-001"));
+//    }
+//
+//    //This test case passes when you try to get all the answers posted for a specific question and the JWT token entered exists in the database but the user corresponding to that JWT token is signed out.
+//    @Test
+//    public void getAllAnswersToQuestionWithSignedOutUser() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.get("/answer/all/database_question_uuid").header("authorization", "database_accesstoken3"))
+//                .andExpect(status().isForbidden())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("ATHR-002"));
+//    }
+//
+//    //This test case passes when you try to get all the answers posted for a specific question which does not exist in the database.
+//    @Test
+//    public void getAllAnswersToNonExistingQuestion() throws Exception {
+//        mvc.perform(MockMvcRequestBuilders.get("/answer/all/non_existing_question_uuid").header("authorization", "database_accesstoken"))
+//                .andExpect(status().isNotFound())
+//                .andExpect(MockMvcResultMatchers.jsonPath("code").value("QUES-001"));
+//    }
 
 
 }
-*/

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/AnswerService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/AnswerService.java
@@ -1,0 +1,46 @@
+package com.upgrad.quora.service.business;
+
+import com.upgrad.quora.service.dao.AnswerDao;
+import com.upgrad.quora.service.entity.AnswerEntity;
+import com.upgrad.quora.service.entity.UserEntity;
+import com.upgrad.quora.service.exception.AnswerNotFoundException;
+import com.upgrad.quora.service.exception.AuthorizationFailedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AnswerService {
+    @Autowired
+    private AnswerDao answerDao;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public AnswerEntity createAnswer(AnswerEntity answerEntity) {
+        return answerDao.createAnswer(answerEntity);
+    }
+
+    @Transactional(propagation =  Propagation.REQUIRED)
+    public AnswerEntity editAnswer(
+            String content,
+            UserEntity user,
+            String answerUuid
+    ) throws AuthorizationFailedException,
+            AnswerNotFoundException {
+        AnswerEntity answerEntity = answerDao.getAnswer(answerUuid);
+        if(answerEntity == null){
+            throw new AnswerNotFoundException(
+                    "ANS-001","Entered answer uuid does not exist"
+            );
+        }
+
+        if (!answerEntity.getUserEntity().getUuid().equals(user.getUuid())) {
+            throw new AuthorizationFailedException(
+                    "ATHR-003",
+                    "Only the answer owner can edit the answer"
+            );
+        }
+
+        return answerDao.updateAnswer(answerEntity);
+    }
+}

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/QuestionService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/QuestionService.java
@@ -32,7 +32,7 @@ public class QuestionService {
 
         return questionDao.createQuestion(questionEntity);
     }
-    
+
     @Transactional(propagation = Propagation.REQUIRED)
     public QuestionEntity editQuestion(String content, long userId, String questionUUID) throws AuthorizationFailedException, InvalidQuestionException{
         QuestionEntity questionEntity = questionDao.getQuestion(questionUUID);
@@ -53,6 +53,15 @@ public class QuestionService {
     @Transactional(propagation = Propagation.REQUIRED)
     public List<QuestionEntity> getAllQuestions() {
         return questionDao.findAll();
+    }
+
+    public QuestionEntity getQuestionById(String questionUUID) throws InvalidQuestionException {
+        QuestionEntity questionEntity = questionDao.getQuestion(questionUUID);
+        if(questionEntity == null)
+        {
+            throw new InvalidQuestionException("QUES-001", "The question entered is invalid");
+        }
+        return questionEntity;
     }
 
 }


### PR DESCRIPTION
Fixed - answer owner comparison (must check uuid of answer owner versus authorization user uuid)
Fixed - Exception handler missing for AnswerNotFoundException
Fixed - create Answer issue with pathVariable for questionId rather than RequestHeader
Passes all Create and Edit Answer test cases
Initially merged to RC tested and now merging to master